### PR TITLE
Dockerfile: apt-get install git

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM rootproject/root:6.28.00-ubuntu22.04
 
-RUN apt-get update && apt-get install -y python3-pip
+RUN apt-get update && apt-get install -y git python3-pip
 
 RUN python3 -m pip install --upgrade wheel jupyter metakernel dask distributed pyspark


### PR DESCRIPTION
This avoids a UI warning in codespaces that unnecessarily worries some users. @klieret @vepadulano 